### PR TITLE
refactor: new statically linked module system removing requirement for cdylib and unsafe code

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -65,8 +65,8 @@ version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -163,7 +163,7 @@ dependencies = [
  "darling",
  "heck",
  "proc-macro-error",
- "quote 1.0.35",
+ "quote",
  "syn 2.0.52",
  "ubyte",
 ]
@@ -203,8 +203,8 @@ dependencies = [
  "lazycell",
  "log",
  "prettyplease",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -266,8 +266,8 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -426,8 +426,8 @@ checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "strsim",
  "syn 2.0.52",
 ]
@@ -439,7 +439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
- "quote 1.0.35",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -465,8 +465,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -479,29 +479,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "dlopen"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e80ad39f814a9abe68583cd50a2d45c8a67561c3361ab8da240587dda80937"
-dependencies = [
- "dlopen_derive",
- "lazy_static",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "dlopen_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f236d9e1b1fbd81cea0f9cbdc8dcc7e8ebcd80e6659cd7cb2ad5f6c05946c581"
-dependencies = [
- "libc",
- "quote 0.6.13",
- "syn 0.15.44",
 ]
 
 [[package]]
@@ -670,8 +647,8 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -709,7 +686,6 @@ dependencies = [
  "anyhow",
  "flate2",
  "geo-types",
- "rayon",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1344,8 +1320,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -1411,8 +1387,8 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -1459,7 +1435,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2",
  "syn 2.0.52",
 ]
 
@@ -1470,8 +1446,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -1482,18 +1458,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
 ]
 
 [[package]]
@@ -1516,20 +1483,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
- "proc-macro2 1.0.78",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1643,8 +1601,6 @@ dependencies = [
  "axum",
  "axum_typed_multipart",
  "decoders",
- "dlopen",
- "dlopen_derive",
  "dotenv",
  "futures-util",
  "generators",
@@ -1756,8 +1712,8 @@ version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -1775,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
@@ -1812,7 +1768,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1878,23 +1833,12 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1904,8 +1848,8 @@ version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -1942,8 +1886,8 @@ version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -1998,8 +1942,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 
@@ -2168,12 +2112,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "url"
@@ -2462,8 +2400,8 @@ version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
+ "proc-macro2",
+ "quote",
  "syn 2.0.52",
 ]
 

--- a/backend/decoders/Cargo.toml
+++ b/backend/decoders/Cargo.toml
@@ -3,17 +3,17 @@ name = "decoders"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
+[build-dependencies]
+shared = { version = "0.1.0", path = "../shared" }
 
 [dependencies]
 shared = { version = "0.1.0", path = "../shared" }
 anyhow = "1.0.80"
 
-# OpenSlide
-openslide-rs = "2.0.1"
+# Optional Dependencies
+openslide-rs = { version = "2.0.1", optional = true }
 
 [features]
 default = ["openslide"]
 
-openslide = []
+openslide = ["dep:openslide-rs"]

--- a/backend/decoders/build.rs
+++ b/backend/decoders/build.rs
@@ -1,0 +1,40 @@
+use shared::functions::{declare_modules, find_exported_struct, find_modules};
+use std::{fs::File, io::Write};
+
+fn main() {
+    let decoders = find_modules();
+    let mut file = File::create("src/lib.rs").unwrap();
+    declare_modules(&mut file, decoders.clone());
+
+    file = File::create("src/export.rs").unwrap();
+
+    writeln!(
+        &mut file,
+        r#"use shared::traits::Decoder;
+        
+pub fn get() -> Vec<Box<dyn Decoder>> {{
+    vec!["#
+    )
+    .unwrap();
+
+    let mut decoders_iter = decoders.iter().peekable();
+    while let Some(decoder) = decoders_iter.next() {
+        let module_file = File::open(format!("src/{}.rs", decoder)).unwrap();
+        let exported_struct = find_exported_struct(module_file).unwrap();
+
+        writeln!(
+            &mut file,
+            r#"        Box::new(crate::{}::{})"#,
+            decoder, exported_struct
+        )
+        .unwrap();
+
+        if decoders_iter.peek().is_none() {
+            writeln!(&mut file, r#"    ]"#).unwrap();
+        } else {
+            writeln!(&mut file, ",").unwrap();
+        }
+    }
+
+    writeln!(&mut file, r#"}}"#).unwrap();
+}

--- a/backend/decoders/src/common.rs
+++ b/backend/decoders/src/common.rs
@@ -1,9 +1,3 @@
 pub use anyhow::Result;
 pub use shared::{structs::Region, traits::Decoder};
 pub use std::path::PathBuf;
-
-// TODO: Avoid manual registration of decoders.
-#[no_mangle]
-pub fn get_decoders() -> Vec<Box<dyn Decoder>> {
-    vec![Box::new(crate::openslide::OpenSlide) as Box<dyn Decoder>]
-}

--- a/backend/decoders/src/export.rs
+++ b/backend/decoders/src/export.rs
@@ -1,0 +1,7 @@
+use shared::traits::Decoder;
+        
+pub fn get() -> Vec<Box<dyn Decoder>> {
+    vec![
+        Box::new(crate::openslide::OpenSlide)
+    ]
+}

--- a/backend/decoders/src/lib.rs
+++ b/backend/decoders/src/lib.rs
@@ -1,3 +1,5 @@
-pub mod common;
+mod common;
+pub mod export;
+
 #[cfg(feature = "openslide")]
-pub mod openslide;
+mod openslide;

--- a/backend/generators/Cargo.toml
+++ b/backend/generators/Cargo.toml
@@ -3,23 +3,22 @@ name = "generators"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib"]
+[build-dependencies]
+shared = { version = "0.1.0", path = "../shared" }
 
 [dependencies]
 shared = { version = "0.1.0", path = "../shared" }
 anyhow = "1.0.80"
 
-# TIAToolbox-specific
-flate2 = "1.0.28"
-geo-types = "0.7.13"
-rayon = "1.9.0"
-rusqlite = { version = "0.31.0", features = ["bundled"] }
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
-wkb = "0.7.1"
+# Optional Dependencies
+flate2 = { version = "1.0.28", optional = true }
+geo-types = { version = "0.7.13", optional = true }
+rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
+serde = { version = "1.0.197", features = ["derive"], optional = true }
+serde_json = { version = "1.0.114", optional = true }
+wkb = { version = "0.7.1", optional = true }
 
 [features]
 default = ["tiatoolbox"]
 
-tiatoolbox = []
+tiatoolbox = ["dep:flate2", "dep:geo-types", "dep:rusqlite", "dep:serde", "dep:serde_json", "dep:wkb"]

--- a/backend/generators/build.rs
+++ b/backend/generators/build.rs
@@ -1,0 +1,53 @@
+use shared::functions::{declare_modules, find_exported_struct, find_modules};
+use std::{fs::File, io::Write};
+
+fn main() {
+    let generators = find_modules();
+    let mut file = File::create("src/lib.rs").unwrap();
+    declare_modules(&mut file, generators.clone());
+
+    file = File::create("src/export.rs").unwrap();
+
+    writeln!(
+        &mut file,
+        r#"use shared::traits::Generator;
+use std::collections::HashMap;
+
+pub fn get() -> HashMap<String, Box<dyn Generator>> {{
+    let mut generators: HashMap<String, Box<dyn Generator>> = HashMap::new();
+    
+    let gs = ["#
+    )
+    .unwrap();
+
+    let mut generators_iter = generators.iter().peekable();
+    while let Some(generator) = generators_iter.next() {
+        let module_file = File::open(format!("src/{}.rs", generator)).unwrap();
+        let exported_struct = find_exported_struct(module_file).unwrap();
+
+        writeln!(
+            &mut file,
+            r#"        crate::{}::{}"#,
+            generator, exported_struct
+        )
+        .unwrap();
+
+        if generators_iter.peek().is_none() {
+            writeln!(&mut file, r#"    ];"#).unwrap();
+        } else {
+            writeln!(&mut file, ",").unwrap();
+        }
+    }
+
+    writeln!(
+        &mut file,
+        r#"
+    for g in gs {{
+        generators.insert(g.name(), Box::new(g));
+    }}
+
+    generators
+}}"#
+    )
+    .unwrap();
+}

--- a/backend/generators/src/common.rs
+++ b/backend/generators/src/common.rs
@@ -1,17 +1,2 @@
 pub use anyhow::Result;
 pub use shared::{structs::AnnotationLayer, traits::Generator};
-use std::collections::HashMap;
-
-// TODO: Avoid manual registration of generators.
-#[no_mangle]
-pub fn get_generators() -> HashMap<String, Box<dyn Generator>> {
-    let mut generators = HashMap::new();
-    let tiatoolbox = crate::tiatoolbox::TIAToolbox;
-
-    generators.insert(
-        tiatoolbox.name(),
-        Box::new(tiatoolbox) as Box<dyn Generator>,
-    );
-
-    generators
-}

--- a/backend/generators/src/export.rs
+++ b/backend/generators/src/export.rs
@@ -1,0 +1,16 @@
+use shared::traits::Generator;
+use std::collections::HashMap;
+
+pub fn get() -> HashMap<String, Box<dyn Generator>> {
+    let mut generators: HashMap<String, Box<dyn Generator>> = HashMap::new();
+    
+    let gs = [
+        crate::tiatoolbox::TIAToolbox
+    ];
+
+    for g in gs {
+        generators.insert(g.name(), Box::new(g));
+    }
+
+    generators
+}

--- a/backend/generators/src/lib.rs
+++ b/backend/generators/src/lib.rs
@@ -1,3 +1,5 @@
 mod common;
+pub mod export;
+
 #[cfg(feature = "tiatoolbox")]
-pub mod tiatoolbox;
+mod tiatoolbox;

--- a/backend/generators/src/tiatoolbox.rs
+++ b/backend/generators/src/tiatoolbox.rs
@@ -91,9 +91,6 @@ impl Generator for TIAToolbox {
             })
         })?;
 
-        println!("Query took: {:?}", start.elapsed());
-        let start = std::time::Instant::now();
-
         let mut colour_index = 0;
         let mut layers = HashMap::new();
 

--- a/backend/rendering-engine/Cargo.toml
+++ b/backend/rendering-engine/Cargo.toml
@@ -12,8 +12,6 @@ anyhow = "1.0.80"
 axum = { version = "0.7.4", features = ["ws", "json"] }
 axum_typed_multipart = "0.11.0"
 dotenv = "0.15.0"
-dlopen = "0.1.8"
-dlopen_derive = "0.1.4"
 futures-util = "0.3.30"
 image = "0.24.9"
 rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/backend/shared/Cargo.toml
+++ b/backend/shared/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.80"
 serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"

--- a/backend/shared/src/functions.rs
+++ b/backend/shared/src/functions.rs
@@ -1,0 +1,76 @@
+use std::{
+    env,
+    fs::{self, File},
+    io::{self, BufRead, Write},
+};
+
+pub fn find_modules() -> Vec<String> {
+    let mut modules = Vec::new();
+
+    let enabled: Vec<String> = env::vars()
+        .filter_map(|(key, _)| {
+            if key.starts_with("CARGO_FEATURE_") {
+                Some(key.trim_start_matches("CARGO_FEATURE_").to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let entries = fs::read_dir("src").expect("Failed to read src directory");
+    for entry in entries {
+        if let Ok(entry) = entry {
+            let path = entry.path();
+            // Filter for files with the .rs extension.
+            let extension = path.extension();
+            if extension.is_none() || extension.unwrap() != "rs" {
+                continue;
+            }
+            if let Some(filename) = path.file_stem() {
+                // Filter out unwanted files.
+                if filename == "common" || filename == "export" || filename == "lib" {
+                    continue;
+                }
+                let module_name = filename.to_string_lossy().to_string();
+                if enabled.contains(&module_name.to_uppercase().replace("-", "_")) {
+                    modules.push(module_name);
+                }
+            }
+        }
+    }
+
+    modules
+}
+
+pub fn find_exported_struct(contents: File) -> Option<String> {
+    // Read the file contents
+    let contents = io::BufReader::new(contents);
+    // Iterate over each line in the file
+    for line in contents.lines() {
+        // Check if the line contains a public struct declaration
+        if let Some(captures) = line.unwrap().strip_prefix("pub struct ") {
+            // Extract the struct name
+            if let Some(struct_name) = captures.split(';').next() {
+                return Some(struct_name.trim().to_string());
+            }
+        }
+    }
+    None
+}
+
+pub fn declare_modules(mut file: &mut dyn Write, modules: Vec<String>) {
+    writeln!(
+        &mut file,
+        r#"mod common;
+pub mod export;
+"#
+    )
+    .expect("Could not write module declaration to file.");
+
+    for module in modules {
+        writeln!(&mut file, "#[cfg(feature = \"{}\")]", module)
+            .expect("Could not write module declaration to file.");
+        writeln!(&mut file, "mod {};", module)
+            .expect("Could not write module declaration to file.");
+    }
+}

--- a/backend/shared/src/lib.rs
+++ b/backend/shared/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod functions;
 pub mod structs;
 pub mod traits;

--- a/backend/shared/src/structs.rs
+++ b/backend/shared/src/structs.rs
@@ -16,7 +16,6 @@ pub struct Address {
     pub y: u32,
 }
 
-pub type Geometry = Vec<[f64; 2]>;
 #[derive(Clone, Debug, Serialize)]
 pub struct AnnotationLayer {
     pub tag: String,
@@ -24,7 +23,7 @@ pub struct AnnotationLayer {
     pub opacity: f32,
     pub fill: String,
     pub stroke: String,
-    pub annotations: Vec<Geometry>,
+    pub annotations: Vec<Vec<[f64; 2]>>,
 }
 
 impl AnnotationLayer {
@@ -39,7 +38,7 @@ impl AnnotationLayer {
         }
     }
 
-    pub fn insert(&mut self, geometry: Geometry) {
+    pub fn insert(&mut self, geometry: Vec<[f64; 2]>) {
         self.annotations.push(geometry);
     }
 }


### PR DESCRIPTION
Completely reworked the module system where lib.rs and export.rs are now autogenerated by build.rs inside of the decoders and generators library crates. This avoids having to dynamically link these modules at runtime using `.so` files and eliminates the use of `unsafe` as well as the `dlopen` crate. This makes it a lot easier to be platform and build type (debug/release) agnostic and is a much more resilient and versatile system.

This refactor also includes the respecting of feature flag such that modules can be turned on and off through the Cargo.toml files in each crate. This refactor also handles the auto-registration of modules that match the specification (i.e. there is a file in the crate for the module and this file exposes a public struct and that there is a feature in the Cargo.toml for that module and that it is enabled). This reduces the files module creators need to edit which reduces the areas where errors can be introduced and makes it easier for modules to be created for the application. Dependencies in these crates are also marked as optional and only included if an enabled module depends on them.