### PR TITLE
Use the glTF format to represent annotation data instead of BufferGeometry in JSON

### DIFF
--- a/backend/geometry-computer/package-lock.json
+++ b/backend/geometry-computer/package-lock.json
@@ -8,8 +8,27 @@
       "name": "geometry-computer",
       "version": "1.0.0",
       "dependencies": {
+        "@gltf-transform/core": "4.0.8",
         "three": "0.168.0"
       }
+    },
+    "node_modules/@gltf-transform/core": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/core/-/core-4.0.8.tgz",
+      "integrity": "sha512-8oSLSw+t+wxPvKC2qm0n3EOoR6Ql2DMuagimjWjGz8sC4MtCqbo6kS6dCeissYrkgP2fj/k8dzRWiWQZRatGMg==",
+      "license": "MIT",
+      "dependencies": {
+        "property-graph": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
+      }
+    },
+    "node_modules/property-graph": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-2.0.0.tgz",
+      "integrity": "sha512-peDswWfLn7Lx+iPIxefhEUbLC7cs1KbfyKqOl5C5TF5F6urnyAORxzQ7JY21yjRzH7CpLa6+d1G+BemBr/lKyw==",
+      "license": "MIT"
     },
     "node_modules/three": {
       "version": "0.168.0",

--- a/backend/geometry-computer/package.json
+++ b/backend/geometry-computer/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "type": "module",
   "dependencies": {
-    "three": "0.168.0"
+    "three": "0.168.0",
+    "@gltf-transform/core": "4.0.8"
   }
 }

--- a/backend/rendering-engine/src/db/image.rs
+++ b/backend/rendering-engine/src/db/image.rs
@@ -191,19 +191,19 @@ pub fn get_annotation_layer_path(
         "#,
     )?;
 
-    let layer = stmt.query_row(
+    let path = stmt.query_row(
         named_params! { ":image_id": image_id, ":annotation_layer_id": annotation_layer_id },
         |row| {
             let tag = row.get::<_, String>(0)?;
-            Ok(parent_directory_path.join(tag + ".json"))
+            Ok(parent_directory_path.join(tag + ".glb"))
         },
     )?;
 
     #[cfg(feature = "log.database")]
     log(
-        &format!("GET <Annotation Layer Path: {image_id}:{}>", layer.0),
+        &format!("GET <Annotation Layer Path: {image_id}:{path}>"),
         Some(&layer),
     );
 
-    Ok(layer)
+    Ok(path)
 }

--- a/frontend/src/lib/api.svelte.ts
+++ b/frontend/src/lib/api.svelte.ts
@@ -36,7 +36,7 @@ const DIRECTORY_MOVE_URL = new URL(HTTP_URL + PUBLIC_DIRECTORY_MOVE_SUBDIR);
 const IMAGE_UPLOAD_URL = new URL(HTTP_URL + PUBLIC_IMAGE_UPLOAD_SUBDIR);
 const IMAGE_DELETE_URL = new URL(HTTP_URL + PUBLIC_IMAGE_DELETE_SUBDIR);
 const IMAGE_PROPERTIES_URL = new URL(HTTP_URL + PUBLIC_IMAGE_PROPERTIES_SUBDIR);
-const IMAGE_ANNOTATIONS_URL = new URL(HTTP_URL + PUBLIC_IMAGE_ANNOTATIONS_SUBDIR);
+export const IMAGE_ANNOTATIONS_URL = new URL(HTTP_URL + PUBLIC_IMAGE_ANNOTATIONS_SUBDIR);
 const WEBSOCKET_URL = new URL(WS_URL + PUBLIC_IMAGE_TILES_SUBDIR);
 
 // General routes.
@@ -55,10 +55,6 @@ export const http = (() => {
 	async function GetProperties(image_id: number) {
 		const url = appendPathSegment(IMAGE_PROPERTIES_URL, image_id);
 		return await GET<Properties>(url);
-	}
-
-	async function GetAnnotations(image_id: number, annotation_layer_id: number) {
-		return await GET<Geometries>(IMAGE_ANNOTATIONS_URL, { image_id, annotation_layer_id });
 	}
 
 	async function CreateDirectory(parent_id: number, name: string) {
@@ -192,7 +188,6 @@ export const http = (() => {
 		GetGenerators,
 		GetRegistry,
 		GetProperties,
-		GetAnnotations,
 		CreateDirectory,
 		DeleteDirectory,
 		MoveDirectory,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -32,8 +32,6 @@ export type AnnotationLayer = {
 	stroke: string;
 };
 
-export type Geometries = string;
-
 export type ImageLayer = HTMLImageElement[][];
 
 export type Directory = {


### PR DESCRIPTION
THe migration to GLB format results in a decrease of the total file size of the annotations from 450MB to 200MB. It is also a format that is made to render as fast as possible so big performance gains were realised.

In the future, will use the `DRACOLoader` instead as that is a compressed version of glTF.